### PR TITLE
Tipo de documento boton editar

### DIFF
--- a/assets/all/php/services.php
+++ b/assets/all/php/services.php
@@ -73,6 +73,9 @@
 		    case 'crear_tipo_docto':
 		        mtdd_ctdd_Function(); 
 		        break;
+		    case 'editar_tipo_docto':
+		        mtdd_etd_Function(); 
+		        break;
 		    case 'load_tipo_docto_list':
 				mtdd_ltdl_Function();
 				break;
@@ -2810,6 +2813,34 @@ error_log($query);
 	        }
 		}else {
 	        $error = 'Falta información requerida para la creación del tipo de documento.';
+	    }
+
+		$jsondata['message'] = $message;
+		$jsondata['error']   = $error;
+		echo json_encode($jsondata);
+	}
+
+	function mtdd_etd_Function(){
+		global $conn;
+		$jsondata = array();
+		$error 	  = '';
+		$message  = '';
+
+		if (isset($_POST['id']) && isset($_POST['nombre']) && isset($_POST['siglas'])){
+			$id = $_POST['id'];
+			$nombre = utf8_encode($_POST['nombre']);
+			$siglas = $_POST['siglas'];
+			
+			$query = "UPDATE tipo_de_documentos SET tipo_de_documento='$nombre', siglas='$siglas' WHERE id='$id'";
+			$execute_query = $conn->query($query);
+
+			if ($execute_query) {
+	            $message = 'Tipo de documento actualizado correctamente en la base de datos.';
+	        } else {
+	            $error = 'Error al actualizar el tipo de documento en la base de datos: ' . $conn->error;
+	        }
+		}else {
+	        $error = 'Falta información requerida para la actualización del tipo de documento.';
 	    }
 
 		$jsondata['message'] = $message;

--- a/assets/manto_tipodocumento/js/core.js
+++ b/assets/manto_tipodocumento/js/core.js
@@ -1,3 +1,8 @@
+// Variables globales para paginación
+var currentPage = 1;
+var itemsPerPage = 10;
+var allData = [];
+
 $(function(){
 
     sidebar();   
@@ -52,13 +57,6 @@ function lista_cambiar_estado(Id, isChecked) {
 }
 
 function load_list() {
-
-    // Obtén la referencia a la tabla
-    var tableBody = $('#cuerpo_tabla');
-
-    // Limpia cualquier contenido previo en la tabla
-    tableBody.empty();
-
     $.ajax({
         contentType: "application/x-www-form-urlencoded",
         type: "POST",
@@ -69,36 +67,15 @@ function load_list() {
         dataType: "json",
         success: function (r) {
             if (r.error === '') {
-                // Verifica si hay datos en la respuesta
                 if (r.data && r.data.length > 0) {
-                    // Recorre los datos y construye las filas de la tabla
-                    $.each(r.data, function (index, tipo_docto) {
-                        var row = $('<tr>');
-                        row.append('<td>' + (tipo_docto.id) + '.</td>');
-                        row.append('<td>' + decodeURI(escape(tipo_docto.nombre)) + '</td>');
-                        row.append('<td>' + decodeURI(escape(tipo_docto.siglas)) + '</td>');
-                        // Crea el switch con el estado adecuado
-                        var switchHtml = '<div class="form-group">' +
-                            '<div class="custom-control custom-switch custom-switch-off-danger custom-switch-on-success">' +
-                            '<input type="checkbox" class="custom-control-input" id="customSwitch' + (tipo_docto.id) + '"';
-                        
-                        // Verifica el estado del rol (como cadena)
-                        if (tipo_docto.status === '1') {
-                            switchHtml += ' checked'; // Si status_rol es '1', enciende el switch
-                        }
-
-                        switchHtml += ' onclick="lista_cambiar_estado(' + tipo_docto.id + ', this.checked)"' + // Agrega el controlador de eventos click
-                            '>' +
-                            '<label class="custom-control-label" for="customSwitch' + tipo_docto.id + '"></label>' +
-                            '</div>' +
-                            '</div>';
-
-                        row.append('<td>' + switchHtml + '</td>');
-                        tableBody.append(row);
-                    });
+                    allData = r.data;
+                    currentPage = 1;
+                    renderTable();
+                    renderPagination();
                 } else {
-                    // No se encontraron roles
-                    tableBody.append('<tr><td colspan="3">No se encontraron tipos de documentos.</td></tr>');
+                    allData = [];
+                    renderTable();
+                    renderPagination();
                 }
             } else {
                 alert(r.error);
@@ -106,6 +83,128 @@ function load_list() {
         },
         beforeSend: function(xhr) {
             xhr.overrideMimeType('text/html;charset=ISO-8859-1');
+        }
+    });
+}
+
+function renderTable() {
+    var tableBody = $('#cuerpo_tabla');
+    tableBody.empty();
+
+    if (allData.length === 0) {
+        tableBody.append('<tr><td colspan="5">No se encontraron tipos de documentos.</td></tr>');
+        return;
+    }
+
+    var start = (currentPage - 1) * itemsPerPage;
+    var end = start + itemsPerPage;
+    var pageData = allData.slice(start, end);
+
+    $.each(pageData, function (index, tipo_docto) {
+        var row = $('<tr>');
+        row.append('<td>' + (start + index + 1) + '.</td>');
+        row.append('<td id="nombre_' + tipo_docto.id + '">' + decodeURI(escape(tipo_docto.nombre)) + '</td>');
+        row.append('<td id="siglas_' + tipo_docto.id + '">' + decodeURI(escape(tipo_docto.siglas)) + '</td>');
+        
+        var switchHtml = '<div class="form-group">' +
+            '<div class="custom-control custom-switch custom-switch-off-danger custom-switch-on-success">' +
+            '<input type="checkbox" class="custom-control-input" id="customSwitch' + (tipo_docto.id) + '"';
+        
+        if (tipo_docto.status === '1') {
+            switchHtml += ' checked';
+        }
+
+        switchHtml += ' onclick="lista_cambiar_estado(' + tipo_docto.id + ', this.checked)"' +
+            '>' +
+            '<label class="custom-control-label" for="customSwitch' + tipo_docto.id + '"></label>' +
+            '</div>' +
+            '</div>';
+
+        row.append('<td>' + switchHtml + '</td>');
+        
+        // Columna de acciones con botón editar
+        var editButton = '<button class="btn btn-sm btn-warning" onclick="editarTipoDocto(' + tipo_docto.id + ')">' +
+                        '<i class="fas fa-edit"></i> Editar</button>';
+        row.append('<td>' + editButton + '</td>');
+        
+        tableBody.append(row);
+    });
+}
+
+function renderPagination() {
+    var totalPages = Math.ceil(allData.length / itemsPerPage);
+    var paginationContainer = $('.pagination');
+    
+    paginationContainer.empty();
+
+    // Solo mostrar paginación si hay más de una página
+    if (totalPages <= 1) {
+        $('.card-footer').hide();
+        return;
+    }
+
+    $('.card-footer').show();
+
+    // Botón anterior
+    var prevDisabled = currentPage === 1 ? 'disabled' : '';
+    paginationContainer.append('<li class="page-item ' + prevDisabled + '"><a class="page-link" href="#" onclick="changePage(' + (currentPage - 1) + ')">&laquo;</a></li>');
+
+    // Números de página
+    for (var i = 1; i <= totalPages; i++) {
+        var active = i === currentPage ? 'active' : '';
+        paginationContainer.append('<li class="page-item ' + active + '"><a class="page-link" href="#" onclick="changePage(' + i + ')">' + i + '</a></li>');
+    }
+
+    // Botón siguiente
+    var nextDisabled = currentPage === totalPages ? 'disabled' : '';
+    paginationContainer.append('<li class="page-item ' + nextDisabled + '"><a class="page-link" href="#" onclick="changePage(' + (currentPage + 1) + ')">&raquo;</a></li>');
+}
+
+function changePage(page) {
+    var totalPages = Math.ceil(allData.length / itemsPerPage);
+    
+    if (page < 1 || page > totalPages) {
+        return;
+    }
+    
+    currentPage = page;
+    renderTable();
+    renderPagination();
+}
+
+function editarTipoDocto(id) {
+    var nombreActual = $('#nombre_' + id).text();
+    var siglasActuales = $('#siglas_' + id).text();
+    
+    var nuevoNombre = prompt('Editar nombre del tipo de documento:', nombreActual);
+    if (nuevoNombre === null) return; // Cancelado
+    
+    var nuevasSiglas = prompt('Editar abreviatura:', siglasActuales);
+    if (nuevasSiglas === null) return; // Cancelado
+    
+    if (nuevoNombre.trim() === '' || nuevasSiglas.trim() === '') {
+        alert('El nombre y la abreviatura no pueden estar vacíos.');
+        return;
+    }
+    
+    $.ajax({
+        contentType: "application/x-www-form-urlencoded",
+        type: "POST",
+        url: "../assets/all/php/services.php",
+        data: {
+            option: 'editar_tipo_docto',
+            id: id,
+            nombre: nuevoNombre.trim(),
+            siglas: nuevasSiglas.trim()
+        },
+        dataType: "json",
+        success: function (response) {
+            if (response.error === '') {
+                alert('Tipo de documento actualizado correctamente.');
+                load_list();
+            } else {
+                alert('Error al actualizar el tipo de documento: ' + response.error);
+            }
         }
     });
 }

--- a/pages/manto_tipodocumento.html
+++ b/pages/manto_tipodocumento.html
@@ -126,68 +126,18 @@
                       <th>Nombre de tipo de documento</th>
                       <th>Abreviatura</th>
                       <th>Activo/Inactivo</th>
+                      <th>Acciones</th>
                     </tr>
                   </thead>
                   <tbody id="cuerpo_tabla">
-                    <tr>
-                      <td>1.</td>
-                      <td>Manual</td>
-                      <td>
-                        <div class="form-group">
-                          <div class="custom-control custom-switch custom-switch-off-danger custom-switch-on-success">
-                            <input type="checkbox" class="custom-control-input" id="customSwitch1">
-                            <label class="custom-control-label" for="customSwitch1"></label>
-                          </div>
-                        </div>
-                      </td>
-                    </tr>
-                    <tr>
-                      <td>2.</td>
-                      <td>Política</td>
-                      <td>
-                        <div class="form-group">
-                          <div class="custom-control custom-switch custom-switch-off-danger custom-switch-on-success">
-                            <input type="checkbox" class="custom-control-input" id="customSwitch2">
-                            <label class="custom-control-label" for="customSwitch2"></label>
-                          </div>
-                        </div>
-                      </td>
-                    </tr>
-                    <tr>
-                      <td>3.</td>
-                      <td>Caracterización de Procesos</td>
-                      <td>
-                        <div class="form-group">
-                          <div class="custom-control custom-switch custom-switch-off-danger custom-switch-on-success">
-                            <input type="checkbox" class="custom-control-input" id="customSwitch3">
-                            <label class="custom-control-label" for="customSwitch3"></label>
-                          </div>
-                        </div>
-                      </td>
-                    </tr>
-                    <tr>
-                      <td>4.</td>
-                      <td>Procedimiento</td>
-                      <td>
-                        <div class="form-group">
-                          <div class="custom-control custom-switch custom-switch-off-danger custom-switch-on-success">
-                            <input type="checkbox" class="custom-control-input" id="customSwitch4">
-                            <label class="custom-control-label" for="customSwitch4"></label>
-                          </div>
-                        </div>
-                      </td>
-                    </tr>
+                    <!-- El contenido se carga dinámicamente via JavaScript -->
                   </tbody>
                 </table>
               </div>
               <!-- /.card-body -->
               <div class="card-footer clearfix">
                 <ul class="pagination pagination-sm m-0 float-right">
-                  <li class="page-item"><a class="page-link" href="#">&laquo;</a></li>
-                  <li class="page-item"><a class="page-link" href="#">1</a></li>
-                  <li class="page-item"><a class="page-link" href="#">2</a></li>
-                  <li class="page-item"><a class="page-link" href="#">3</a></li>
-                  <li class="page-item"><a class="page-link" href="#">&raquo;</a></li>
+                  <!-- La paginación se genera dinámicamente via JavaScript -->
                 </ul>
               </div>
             </div>


### PR DESCRIPTION
  Análisis de impacto: Los tipos de documento solo se referencian por ID en otras partes del sistema, por lo
  que editar nombres y siglas es seguro.

  Frontend (HTML):
  - Agregada columna "Acciones" en la tabla
  - Contenido de la tabla ahora se carga dinámicamente
  - Paginación automática restaurada

  JavaScript:
  - Paginación automática que se oculta cuando hay ≤10 elementos
  - Función editarTipoDocto() que permite editar nombre y siglas via prompts
  - Botón "Editar" en cada fila con icono de Font Awesome
  - Recarga automática de la tabla después de editar

  Backend (PHP):
  - Nuevo endpoint editar_tipo_docto
  - Función mtdd_etd_Function() que actualiza la base de datos
  - Validación de parámetros requeridos
  - Manejo de errores

  La edición es segura ya que solo cambia nombres y abreviaturas, manteniendo los IDs que otros módulos
  referencian.